### PR TITLE
Give some more love to the SEO Profiler panel

### DIFF
--- a/bin/lint-twig.php
+++ b/bin/lint-twig.php
@@ -4,12 +4,17 @@
 require __DIR__.'/../vendor/autoload.php';
 
 use Symfony\Bridge\Twig\Command\LintCommand;
+use Symfony\Bundle\WebProfilerBundle\Twig\WebProfilerExtension;
 use Symfony\Component\Console\Application;
+use Symfony\Component\VarDumper\Dumper\HtmlDumper;
 use Twig\Environment;
 use Twig\Loader\FilesystemLoader;
 
+$twig = new Environment(new FilesystemLoader());
+$twig->addExtension(new WebProfilerExtension(new HtmlDumper()));
+
 (new Application('twig/lint'))
-    ->add(new LintCommand(new Environment(new FilesystemLoader())))
+    ->add(new LintCommand($twig))
     ->getApplication()
     ->setDefaultCommand('lint:twig', true)
     ->run();

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,8 @@
         "symfony/console": "^4.4|^5.1",
         "symfony/filesystem": "^4.4|^5.1",
         "symfony/phpunit-bridge": "^5.2",
-        "symfony/twig-bridge": "^4.4|^5.1"
+        "symfony/twig-bridge": "^4.4|^5.1",
+        "symfony/web-profiler-bundle": "^4.4|^5.1"
     },
     "extra": {
         "branch-alias": {

--- a/src/Checker/ImageChecker.php
+++ b/src/Checker/ImageChecker.php
@@ -37,7 +37,7 @@ class ImageChecker
         $images = $this->crawler->filter('img')->extract(['src', 'alt']);
         $missingAlt = array_filter($images, function ($img) { return '' === $img[1]; });
 
-        return array_map(function ($img) { return $img[0]; }, $missingAlt);
+        return array_values(array_map(function ($img) { return $img[0]; }, $missingAlt));
     }
 
     public function countIcons(): int

--- a/src/Checker/OptimizationChecker.php
+++ b/src/Checker/OptimizationChecker.php
@@ -166,7 +166,7 @@ class OptimizationChecker
 
     public function isHreflang(): bool
     {
-        return \count($this->getHreflang()) > 1;
+        return \count($this->getHreflang()) >= 1;
     }
 
     public function getHreflang(): array

--- a/src/DataCollector/AccessibilityCollector.php
+++ b/src/DataCollector/AccessibilityCollector.php
@@ -11,6 +11,7 @@ use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\DataCollector;
+use Symfony\Component\VarDumper\Cloner\Data;
 use Symfony\Component\Stopwatch\Stopwatch;
 
 class AccessibilityCollector extends DataCollector
@@ -63,6 +64,8 @@ class AccessibilityCollector extends DataCollector
             'brokenLinks' => $this->brokenLinkChecker->getExternalBrokenLinks(),
         ];
 
+        $this->data = $this->cloneVar($this->data);
+
         if (isset($event)) {
             $event->stop();
         }
@@ -73,9 +76,14 @@ class AccessibilityCollector extends DataCollector
         $this->data = [];
     }
 
+    public function seek(string $key): Data
+    {
+        return $this->data->seek($key);
+    }
+
     public function getBrokenLinks(): ?array
     {
-        return $this->data['brokenLinks'];
+        return $this->data['brokenLinks']->getValue();
     }
 
     public function isForm(): bool
@@ -90,17 +98,17 @@ class AccessibilityCollector extends DataCollector
 
     public function getMissingAssociatedLabelForInput(): array
     {
-        return $this->data['missingAssociatedLabelForInput'];
+        return $this->data['missingAssociatedLabelForInput']->getValue();
     }
 
     public function listMissingAltFromImages(): array
     {
-        return $this->data['listMissingAltFromImages'];
+        return $this->data['listMissingAltFromImages']->getValue();
     }
 
     public function listNonExplicitIcons(): array
     {
-        return $this->data['listNonExplicitIcons'];
+        return $this->data['listNonExplicitIcons']->getValue();
     }
 
     public function getCountAllIcons(): int

--- a/src/DataCollector/SeoCollector.php
+++ b/src/DataCollector/SeoCollector.php
@@ -15,6 +15,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\DataCollector;
 use Symfony\Component\HttpKernel\DataCollector\LateDataCollectorInterface;
 use Symfony\Component\Stopwatch\Stopwatch;
+use Symfony\Component\VarDumper\Cloner\Data;
 
 class SeoCollector extends DataCollector implements LateDataCollectorInterface
 {
@@ -93,6 +94,8 @@ class SeoCollector extends DataCollector implements LateDataCollectorInterface
         $this->data['metaGooglebot'] = $this->robotDirectivesChecker->getMetaGooglebotsTag();
         $this->data['metaGooglebotNews'] = $this->robotDirectivesChecker->getMetaGooglebotNewsTag();
         $this->data['language'] = $this->robotDirectivesChecker->getLanguage();
+
+        $this->data = $this->cloneVar($this->data);
     }
 
     public function reset(): void
@@ -100,9 +103,19 @@ class SeoCollector extends DataCollector implements LateDataCollectorInterface
         $this->data = [];
     }
 
+    public function getData()
+    {
+        return $this->data;
+    }
+
+    public function seek(string $key): Data
+    {
+        return $this->data->seek($key);
+    }
+
     public function getHreflang(): array
     {
-        return $this->data['hreflang'];
+        return $this->data['hreflang']->getValue();
     }
 
     public function isHreflang(): bool
@@ -112,12 +125,12 @@ class SeoCollector extends DataCollector implements LateDataCollectorInterface
 
     public function getExternalBrokenLinks(): array
     {
-        return $this->data['externalBrokenLinks'];
+        return $this->data['externalBrokenLinks']->getValue();
     }
 
     public function getHeadlinesTree(): array
     {
-        return $this->data['headlinesTree'];
+        return $this->data['headlinesTree']->getValue();
     }
 
     public function getLanguage(): ?string
@@ -127,17 +140,19 @@ class SeoCollector extends DataCollector implements LateDataCollectorInterface
 
     public function getCountHeadlines(): array
     {
-        return $this->data['countHeadlines'];
+        return array_map(static function (Data $data): int {
+            return $data->getValue();
+        }, $this->data['countHeadlines']->getValue());
     }
 
     public function getMissingTwitterProperties(): array
     {
-        return $this->data['missingTwitterProperties'];
+        return $this->data['missingTwitterProperties']->getValue();
     }
 
     public function getMissingOpenGraphProperties(): array
     {
-        return $this->data['missingOpenGraphProperties'];
+        return $this->data['missingOpenGraphProperties']->getValue();
     }
 
     public function getAtLeastOneH1(): bool
@@ -147,12 +162,12 @@ class SeoCollector extends DataCollector implements LateDataCollectorInterface
 
     public function getOpenGraphProperties(): array
     {
-        return $this->data['OpenGraphProperties'];
+        return $this->data['OpenGraphProperties']->getValue();
     }
 
     public function getTwitterProperties(): array
     {
-        return $this->data['twitterProperties'];
+        return $this->data['twitterProperties']->getValue();
     }
 
     public function getTitle(): ?string

--- a/templates/profiler/accessibility_collector.html.twig
+++ b/templates/profiler/accessibility_collector.html.twig
@@ -36,6 +36,12 @@
 {% block head %}
     {# Optional. Here you can link to or define your own CSS and JS contents. #}
     {# Use {{ parent() }} to extend the default styles instead of overriding them. #}
+    <style>
+        .text-warning {
+            color: var(--color-warning);
+        }
+        .tab-navigation li .badge.status-success { background: var(--color-success); color: #FFF; }
+    </style>
     {{ parent() }}
 {% endblock %}
 
@@ -53,7 +59,7 @@
     {# Optional, for showing the most details. #}
     <h2>Accessibility ✨</h2>
 
-    <h3>Images:</h3>
+    <h3>Images</h3>
 
     <div class="metrics">
         <div class="metric">
@@ -65,20 +71,23 @@
             <span class="label">Images with balise alt</span>
         </div>
     </div>
-    <table>
-        <tr>
-            <th>Images whithout alt attribute:</th>
-            <td>
-                {% for image in collector.listMissingAltFromImages %}
-                    {{ image }}<br>
-                    {% else %}
-                    <span class="help">Nothing to display.</span>
-                {% endfor %}
-            </td>
-        </tr>
-    </table>
 
-    <h3>Icons:</h3>
+    <h4>Images whithout alt attribute</h4>
+    {% if collector.listMissingAltFromImages > 0 %}
+        <table>
+            <tr>
+                <td>
+                    {{ profiler_dump(collector.seek('listMissingAltFromImages'), maxDepth=1) }}
+                </td>
+            </tr>
+        </table>
+    {% else %}
+        <div class="empty">
+            <p>Nothing to display</p>
+        </div>
+    {% endif %}
+
+    <h3>Icons</h3>
     <div class="metrics">
         <div class="metric">
             <span class="value">{{ collector.countAllIcons }}</span>
@@ -89,32 +98,38 @@
             <span class="label">Non-explicit icons</span>
         </div>
     </div>
-    <table>
-        <tr>
-            <th>Class of icons missing aria-hidden attribute:</th>
-            <td>
-                {% for icons in collector.listNonExplicitIcons %}
-                    {{ icons }}<br>
-                {% else %}
-                    <span class="help">Nothing to display.</span>
-                {% endfor %}
-            </td>
-        </tr>
-    </table>
 
-    <h3>Forms</h3>
+    <h4>Class of icons missing aria-hidden attribute</h4>
+    {% if collector.listNonExplicitIcons > 0 %}
         <table>
             <tr>
-                <th>Missing associated label for input:</th>
                 <td>
-                    {% for input in collector.missingAssociatedLabelForInput %}
-                        {{ input }}<br>
-                    {% else %}
-                        <span class="help">Nothing to display.</span>
-                    {% endfor %}
+                    {{ profiler_dump(collector.seek('listNonExplicitIcons'), maxDepth=1) }}
                 </td>
             </tr>
         </table>
+    {% else %}
+        <div class="empty">
+            <p>Nothing to display</p>
+        </div>
+    {% endif %}
+
+    <h3>Forms</h3>
+
+    {% if collector.isForm %}
+        <table>
+            <tr>
+            <th>Missing associated label for input</th>
+                    <td>
+                        {{ profiler_dump(collector.seek('missingAssociatedLabelForInput'), maxDepth=1) }}
+                    </td>
+            </tr>
+        </table>
+    {% else %}
+        <div class="empty">
+            <p>No Forms</p>
+        </div>
+    {% endif %}
 
     <h3>Broken external links</h3>
     <table>

--- a/templates/profiler/seo_collector.html.twig
+++ b/templates/profiler/seo_collector.html.twig
@@ -13,15 +13,15 @@
         {# this is the content displayed when hovering the mouse over
            the toolbar panel #}
         <div class="sf-toolbar-info-piece">
-            <b>Title:</b>
+            <b>Title</b>
             <span>{{ collector.title }}</span>
         </div>
         <div class="sf-toolbar-info-piece">
-            <b>Meta Description:</b>
+            <b>Meta Description</b>
             <span>{{ collector.metaDescription }}</span>
         </div>
         <div class="sf-toolbar-info-piece">
-            <b>First H1 found:</b>
+            <b>First H1 found</b>
             {% if collector.atLeastOneH1 %}
                 <span>{{ collector.h1 }}</span>
             {% else %}
@@ -29,11 +29,11 @@
             {% endif %}
         </div>
         <div class="sf-toolbar-info-piece">
-            <b>X-Robots-Tag:</b>
+            <b>X-Robots-Tag</b>
             <span>{{ collector.XRobotsTag }}</span>
         </div>
         <div class="sf-toolbar-info-piece">
-            <b>Canonical:</b>
+            <b>Canonical</b>
             {% if collector.canonical %}
                 <span>{{ collector.canonical }}</span>
             {% else %}
@@ -50,6 +50,12 @@
     {# Optional. Here you can link to or define your own CSS and JS contents. #}
     {# Use {{ parent() }} to extend the default styles instead of overriding them. #}
     {{ parent() }}
+    <style>
+        .text-warning {
+            color: var(--color-warning);
+        }
+        .tab-navigation li .badge.status-success { background: var(--color-success); color: #FFF; }
+    </style>
 {% endblock %}
 
 {% block menu %}
@@ -65,60 +71,56 @@
 {% block panel %}
     {# Optional, for showing the most details. #}
     <h2>SEO insights ✨</h2>
-        <h3>SEO main optimizations:</h3>
-            <table>
-                    <tr>
-                        <th>Title:</th>
-                        {% if collector.title %}
-                            <td>{{ collector.title }}</td>
-                        {% else %}
-                            <td><span class="help">Not title found</span></td>
-                        {% endif %}
-                    </tr>
-                    <tr>
-                        <th>Meta description:</th>
-                        {% if collector.metaDescription %}
-                            <td>{{ collector.metaDescription }}</td>
-                        {% else %}
-                            <td><span class="help">Not meta description found</span></td>
-                        {% endif %}
-                    </tr>
-                    <tr>
-                        <th>First H1:</th>
-                        {% if collector.h1 %}
-                            <td>{{ collector.h1 }}</td>
-                        {% else %}
-                            <td><span class="help">Not H1 found</span></td>
-                        {% endif %}
-                    </tr>
-                    <tr>
-                        <th>Headings:</th>
-                        <td>
-                            {% set headings = collector.headlinesTree %}
-                            {% block treeHeading %}
-                                <div>
-                                    {% for heading in headings %}
-                                        {% for i in 1..heading.level %}&nbsp;&nbsp;{% endfor %}- H{{ heading.level }}: {{ heading.content }}
 
-                                        {% set headings = heading.children %}
-                                        {{ block ("treeHeading") }}
-                                    {% endfor %}
+    <h3>SEO main optimizations</h3>
+        <table>
+            <tr>
+                <th>Title</th>
+                <td>{{ profiler_dump(collector.seek('title')) }}</td>
+            </tr>
+            <tr>
+                <th>Meta description</th>
+                <td>{{ profiler_dump(collector.seek('metaDescription')) }}</td>
+            </tr>
+            <tr>
+                <th>First H1</th>
+                <td>{{ profiler_dump(collector.seek('h1')) }}</td>
+            </tr>
+            <tr>
+                <th>Headings</th>
+                <td>
+                    {% set headings = collector.headlinesTree %}
+                    {% set level = 1 %}
+                    {% block treeHeading %}
+                        <div>
+                            <ul>
+                                {% for heading in headings %}
+                                    <li>
+                                        <span class="{{ level != heading.level ? 'text-warning' }}">
+                                            H{{ heading.level }}: {{ heading.content }}
+                                        </span>
+                                    </li>
+                                    {% set headings = heading.children %}
+                                    {% set level = level+1 %}
+                                    {{ block ("treeHeading") }}
+                                    {% set level = level-1 %}
+                                {% endfor %}
+                            </ul>
+                        </div>
+                    {% endblock %}
+                </td>
 
-                                </div>
-                            {% endblock %}
-                        </td>
+            </tr>
+        </table>
 
-                    </tr>
-            </table>
-
-        <h3>Directives for robots:</h3>
+        <h3>Directives for robots</h3>
             <div class="metrics">
                 <div class="metric">
                     <span class="value">
                     {% if collector.canonical %}
-                        <td>collector.canonical</td>
+                        <a href="{{ collector.canonical }}">{{ collector.canonical }}</a>
                     {% else %}
-                        <td><span class="help">Not found</span></td>
+                        {{ include('@WebProfiler/Icon/no-gray.svg') }}
                     {% endif %}
                     </span>
                     <span class="label">Canonical</span>
@@ -126,9 +128,9 @@
                 <div class="metric">
                     <span class="value">
                     {% if collector.language %}
-                        <td>collector.language</td>
+                        {{ collector.language }}
                     {% else %}
-                        <td><span class="help">Not found</span></td>
+                        {{ include('@WebProfiler/Icon/no-gray.svg') }}
                     {% endif %}
                     </span>
                     <span class="label">Language</span>
@@ -140,98 +142,122 @@
                 <div class="metric">
                     <span class="value">
                         {% if collector.isHreflang %}
-                        <td><span class="help">Found</span></td>
+                            {{ include('@WebProfiler/Icon/yes.svg') }}
                         {% else %}
-                        <td><span class="help">Not found</span></td>
+                            {{ include('@WebProfiler/Icon/no-gray.svg') }}
                         {% endif %}
                     </span>
                     <span class="label">Hreflang</span>
                 </div>
             </div>
             <table>
-                    <tr>
-                        <th>Meta Robots:</th>
-                        {% if collector.metaRobot %}
-                            <td><span>{{ collector.metaRobot }}</span></td>
-                        {% else %}
-                            <td><span class="help">Not found</span></td>
-                        {% endif %}
-                    </tr>
-                    <tr>
-                        <th>Meta Googlebot:</th>
-                        {% if collector.metaGooglebot %}
-                            <td><span>{{ collector.metaGooglebot }}</span></td>
-                        {% else %}
-                            <td><span class="help">Not found</span></td>
-                        {% endif %}
-                    </tr>
-                    <tr>
-                        <th>Meta Googlebot-news:</th>
-                        {% if collector.metaGooglebotNews %}
-                            <td><span>{{ collector.metaGooglebotNews }}</span></td>
-                        {% else %}
-                            <td><span class="help">Not found</span></td>
-                        {% endif %}
-                    </tr>
-            </table>
-    <h3>Hreflang:</h3>
-    {% if collector.isHreflang %}
-            <table>
-            {% for href in collector.hreflang %}
                 <tr>
-                    <th>{{ href['hreflang'] }}</th>
-                    <td>
-                        {{ href['href'] }}
-                    </td>
+                    <th>Meta Robots</th>
+                    <td>{{ profiler_dump(collector.seek('metaRobot')) }}</td>
                 </tr>
-            {% endfor %}
+                <tr>
+                    <th>Meta Googlebot</th>
+                    <td>{{ profiler_dump(collector.seek('metaGooglebot')) }}</td>
+                </tr>
+                <tr>
+                    <th>Meta Googlebot-news</th>
+                    <td>{{ profiler_dump(collector.seek('metaGooglebotNews')) }}</td>
+                </tr>
             </table>
-    {% else %}
+
+    <h3>Hreflang</h3>
+
+    {% if collector.isHrefLang %}
         <table>
-            <td><span class="help">No hreflang tags.</span></td>
+        {% for href in collector.hreflang %}
+            <tr>
+                <th>{{ href['hreflang'] }}</th>
+                <td>
+                    <a href="{{ href['href'] }}">{{ href['href'] }}</a>
+                </td>
+            </tr>
+        {% endfor %}
         </table>
+    {% else %}
+        <div class="empty">
+            <p>No hreflang tags</p>
+        </div>
     {% endif %}
-        <h3>Share on Social Media:</h3>
-            <table>
-                <tr>
-                    <th>OpenGraph completed:</th>
-                    <td>{{ collector.OpenGraphLevel }}</td>
-                </tr>
-                <tr>
-                    <th>Fulfilled properties:</th>
-                    <td>
-                        {% for key, content in collector.OpenGraphProperties %}
-                         {{ key }}: {{ content }} <br>
-                        {% endfor %}
-                    </td>
-                </tr>
-                <tr>
-                    <th>Missing properties:</th>
-                    <td>
-                        {% for key, content in collector.missingOpenGraphProperties %}
-                            {{ content }} <br>
-                        {% endfor %}
-                    </td>
-                </tr>
-                <tr>
-                    <th>Twitter card completed:</th>
-                    <td>{{ collector.twitterPropertiesLevel }}</td>
-                </tr>
-                <tr>
-                    <th>Fulfilled properties:</th>
-                    <td>
-                        {% for key, content in collector.twitterProperties %}
-                         {{ key }}: {{ content }} <br>
-                        {% endfor %}
-                    </td>
-                </tr>
-                <tr>
-                    <th>Missing properties:</th>
-                    <td>
-                        {% for key, content in collector.missingTwitterProperties %}
-                            {{ content }} <br>
-                        {% endfor %}
-                    </td>
-                </tr>
-            </table>
+
+    <h3>Share on Social Media</h3>
+
+    <div class="metrics">
+        <div class="metric">
+            <span class="value">
+                {% if collector.OpenGraphLevel == 'completed' %}
+                    {{ include('@WebProfiler/Icon/yes.svg') }}
+                {% else %}
+                    {{ include('@WebProfiler/Icon/no-gray.svg') }}
+                {% endif %}
+            </span>
+            <span class="label">OpenGraph</span>
+        </div>
+        <div class="metric">
+            <span class="value">
+                {% if collector.twitterPropertiesLevel == 'completed' %}
+                    {{ include('@WebProfiler/Icon/yes.svg') }}
+                {% else %}
+                    {{ include('@WebProfiler/Icon/no-gray.svg') }}
+                {% endif %}
+            </span>
+            <span class="label">Twitter card</span>
+        </div>
+    </div>
+
+    <div class="sf-tabs">
+        <div class="tab">
+            <h4 class="tab-title">
+                Opengraph
+                <span class="badge {{ collector.OpenGraphLevel == 'completed' ? 'status-success' }}">
+                    {{ collector.OpenGraphProperties|length }}
+                </span>
+            </h4>
+            <div class="tab-content">
+                <table>
+                    <tr>
+                        <th>Fulfilled properties</th>
+                        <td>
+                            {{ profiler_dump(collector.seek('OpenGraphProperties'), maxDepth=1) }}
+                        </td>
+                    </tr>
+                    <tr>
+                        <th>Missing properties</th>
+                        <td>
+                            {{ profiler_dump(collector.seek('missingOpenGraphProperties'), maxDepth=1) }}
+                        </td>
+                    </tr>
+                </table>
+            </div>
+        </div>
+
+        <div class="tab">
+            <h4 class="tab-title">Twitter
+                card
+                <span class="badge {{ collector.twitterPropertiesLevel == 'completed' ? 'status-success' }}">
+                    {{ collector.twitterProperties|length }}
+                </span>
+            </h4>
+            <div class="tab-content">
+                <table>
+                    <tr>
+                        <th>Fulfilled properties</th>
+                        <td>
+                            {{ profiler_dump(collector.seek('twitterProperties'), maxDepth=1) }}
+                        </td>
+                    </tr>
+                    <tr>
+                        <th>Missing properties</th>
+                        <td>
+                            {{ profiler_dump(collector.seek('missingTwitterProperties'), maxDepth=1) }}
+                        </td>
+                    </tr>
+                </table>
+            </div>
+        </div>
+    </div>
 {% endblock %}

--- a/templates/profiler/seo_collector.html.twig
+++ b/templates/profiler/seo_collector.html.twig
@@ -25,7 +25,7 @@
             {% if collector.atLeastOneH1 %}
                 <span>{{ collector.h1 }}</span>
             {% else %}
-                <span>No H1 founded</span>
+                <span>No H1 found</span>
             {% endif %}
         </div>
         <div class="sf-toolbar-info-piece">


### PR DESCRIPTION
Reusing common "patterns" used by other profilers and the VarDumper for rendering data.

Some UI changes screenshots:

### General

![Capture d’écran 2020-12-18 à 16 17 00](https://user-images.githubusercontent.com/2211145/102630747-373d8d00-414d-11eb-8b07-050d7138749c.png)

### Robots

![Capture d’écran 2020-12-18 à 15 46 57](https://user-images.githubusercontent.com/2211145/102630800-46243f80-414d-11eb-8b5b-fa0e805d80ad.png)
![Capture d’écran 2020-12-18 à 15 49 37](https://user-images.githubusercontent.com/2211145/102630822-4d4b4d80-414d-11eb-84bd-e110bcae0653.png)

### Social

![Capture d’écran 2020-12-18 à 16 10 12](https://user-images.githubusercontent.com/2211145/102630765-3d336e00-414d-11eb-9121-fa4efc3f9be4.png)

(actually, for this one we could even render a table for `properties => values`)