### PR TITLE
Monitor collect with Stopwatch

### DIFF
--- a/config/services.xml
+++ b/config/services.xml
@@ -8,9 +8,11 @@
         <defaults public="false" />
 
         <service id="Elao\Bundle\SeoTool\DataCollector\SeoCollector">
+            <argument type="service" id="debug.stopwatch" on-invalid="null" />
             <tag name="data_collector" template="@ElaoSeoTool/profiler/seo_collector.html.twig" id="elao.seo_tool.seo_collector" />
         </service>
         <service id="Elao\Bundle\SeoTool\DataCollector\AccessibilityCollector">
+            <argument type="service" id="debug.stopwatch" on-invalid="null" />
             <tag name="data_collector" template="@ElaoSeoTool/profiler/accessibility_collector.html.twig" id="elao.seo_tool.accessibility_collector" />
         </service>
 


### PR DESCRIPTION
So we can monitor and impute time being passed collecting data for the SEO & Accessibility metrics from the page performances.

![Capture d’écran 2020-12-23 à 16 20 43](https://user-images.githubusercontent.com/2211145/103011916-0be6e380-453b-11eb-9a81-5bd5bf0958ec.png)

Later, we could monitor each of the checkers if we want.